### PR TITLE
fix: prompt inconsistency

### DIFF
--- a/sparc/prompt.py
+++ b/sparc/prompt.py
@@ -133,5 +133,5 @@ Now we can draw a line to (5,0) to reach the end node.
 
 **Example Solution Path Format:**
 ####
-[(0, 0), (1, 0), (2, 0), (2, 1), ...]
+(0,0), (1,0), (2,0), (2,1), ...
 """


### PR DESCRIPTION
Here, we use no []:

https://github.com/lkaesberg/SPaRC/blob/4d4faa103da95307bcfbce51889807405284772c/sparc/prompt.py#L112-L115

But here we do:

https://github.com/lkaesberg/SPaRC/blob/4d4faa103da95307bcfbce51889807405284772c/sparc/prompt.py#L134-L137

Fixed it to avoid output path formatting issues.